### PR TITLE
Modifications to zig contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 neardev/
 .DS_Store
+.zig-cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 *.o
 neardev/
 .DS_Store
-.zig-cache

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ to deploy website tied to your `.near` account, with static content hosted on IP
 
 ## Building from source
 
-Install [Zig](https://ziglang.org/learn/getting-started/#installing-zig) first.
+Install [Zig](https://ziglang.org/learn/getting-started/#installing-zig). Below command uses [v0.13.0](https://github.com/ziglang/zig/releases/tag/0.13.0).
 
 Then run:
 
 ```bash
-zig build-lib web4-min.zig -target wasm32-freestanding -dynamic -rdynamic -OReleaseSmall
+zig build-exe web4-min.zig -target wasm32-freestanding -O ReleaseSmall --export=web4_get --export=web4_setStaticUrl --export=web4_setOwner -fno-entry
 ```
 
 You should get `web4-min.wasm` file.
 
 ## Deploying smart contract
 
-Install [near-cli](https://github.com/near/near-cli) first.
+Install [near-cli-rs](https://github.com/near/near-cli-rs) first.
 
 Then run:
 

--- a/web4-min.zig
+++ b/web4-min.zig
@@ -105,7 +105,7 @@ fn assertSelfOrOwner() void {
 const DEFAULT_STATIC_URL = "ipfs://bafybeidc4lvv4bld66h4rmy2jvgjdrgul5ub5s75vbqrcbjd3jeaqnyd5e";
 
 // Main entry point for web4 contract.
-pub export fn web4_get() void {
+export fn web4_get() void {
     // Read method arguments blob
     const inputData = readInputAlloc();
 
@@ -163,7 +163,7 @@ fn extract_string(inputData: []const u8, keyName: []const u8) []const u8 {
 
 // Update current static content URL in smart contract storage
 // NOTE: This is useful for web4-deploy tool
-pub export fn web4_setStaticUrl() void {
+export fn web4_setStaticUrl() void {
     assertSelfOrOwner();
 
     // Read method arguments blob
@@ -181,7 +181,7 @@ pub export fn web4_setStaticUrl() void {
 
 // Update current owner account ID – if set this account can update contract config
 // NOTE: This is useful to deploy contract to subaccount like web4.<account_id>.near and then transfer ownership to <account_id>.near
-pub export fn web4_setOwner() void {
+export fn web4_setOwner() void {
     assertSelfOrOwner();
 
     // Read method arguments blob

--- a/web4-min.zig
+++ b/web4-min.zig
@@ -167,7 +167,7 @@ export fn web4_setStaticUrl() void {
     const inputData = readInputAlloc();
 
     // Parse method arguments JSON and extract staticUrl
-    const staticUrl = extract_string(inputData, "staticUrl") orelse DEFAULT_STATIC_URL;
+    const staticUrl = extract_string(inputData, "url") orelse DEFAULT_STATIC_URL;
 
     // Log updated URL
     log(joinAlloc(.{ "staticUrl: ", staticUrl }));


### PR DESCRIPTION
I've been having issues working with the Zig contract, these are the changes I needed to make:

(this is using latest Zig, 0.13.0)
- [x] remove -dynamic and -rdynamic flags, [incompatible with wasm target](https://github.com/ziglang/zig/issues/18825)
- [x] convert to build-exe and specify no entry (fno-entry as of 0.13.0)
- [x] explicitly export functions in build, otherwise unable to inspect abi or call (MethodNotFound)
- [x] std.mem.copy -> @memcpy as of latest version
- [x] use a default static url deployed to both [mainnet](https://ipfs.web4.near.page/ipfs/bafybeidc4lvv4bld66h4rmy2jvgjdrgul5ub5s75vbqrcbjd3jeaqnyd5e/) and [testnet](https://ipfs.web4.testnet.page/ipfs/bafybeidc4lvv4bld66h4rmy2jvgjdrgul5ub5s75vbqrcbjd3jeaqnyd5e/)
- [x] fixes web4_setStaticUrl parameter name from staticUrl -> url (web4-deploy calls with url, and defined this way in readme)
- [x] able to use custom static url 

This pull request accompanies an update to web4-deploy: [see here](https://github.com/vgrichina/web4-deploy/pull/8).